### PR TITLE
Lovecraftian omen cats can be targeted by Bast's Guardian spell.

### DIFF
--- a/Patches/patches.xml
+++ b/Patches/patches.xml
@@ -39,5 +39,10 @@
 	</operations>
   </Operation>
 
+  <Operation Class="PatchOperationAdd">
+      <!-- If the HP Lovecraft storyteller is loaded, make it so cats from that mod can also be transformed into Guardians of Bast. -->
+      <xpath>Defs/IncidentDef[defName="Cults_BastSpellSummonGuardian"]/modExtensions/li[@Class="BastCult.GuardianProperties"]/eligiblePawnDefs</xpath>
+      <value><li>HPLovecraft_CatRace</li></value>
+  </Operation>
 
 </Patch>

--- a/Patches/patches.xml
+++ b/Patches/patches.xml
@@ -41,6 +41,7 @@
 
   <Operation Class="PatchOperationAdd">
       <!-- If the HP Lovecraft storyteller is loaded, make it so cats from that mod can also be transformed into Guardians of Bast. -->
+      <success>Always</success>
       <xpath>Defs/IncidentDef[defName="Cults_BastSpellSummonGuardian"]/modExtensions/li[@Class="BastCult.GuardianProperties"]/eligiblePawnDefs</xpath>
       <value><li>HPLovecraft_CatRace</li></value>
   </Operation>


### PR DESCRIPTION
Black cats are the best cats, and now they can be transformed into Guardians of Bast.

<s>Note that my xpath skills are a little green. This code doesn't have a guard to ensure the Lovecraftian storyteller is installed. (But it's tested and working when the Lovecraftian storyteller is enabled.)</s>

Edit: Added a `<success>Always</success>` decoration so the patch should become a no-op if the Lovecraftian storyteller is not installed.