### PR TITLE
Bugfix: Sacrificial dagger checks against defName MeleeWeapon_CultKris

### DIFF
--- a/Source/Utilities/CultUtility.cs
+++ b/Source/Utilities/CultUtility.cs
@@ -923,7 +923,7 @@ namespace CultOfCthulhu
                 {
                     foreach (ThingWithComps eq in member.equipment.AllEquipmentListForReading)
                     {
-                        if (eq.def.defName == "")
+                        if (eq.def.defName == "MeleeWeapon_CultKris")
                         {
                             sacrificialDagger = true;
                             result += 0.005f;


### PR DESCRIPTION
After noticing that my cult didn't get a bonus for wielding a kris, I looked at the code and discovered it was testing against an empty-string.

This change updates the test to look for `MeleeWeapon_CultKris`.

---

Update: Have tested this on my current game and it works! :)