### PR TITLE
CultUtility.cs: Bugfix: Fix flipped stars are right/wrong

### DIFF
--- a/Source/Utilities/CultUtility.cs
+++ b/Source/Utilities/CultUtility.cs
@@ -469,15 +469,15 @@ namespace CultOfCthulhu
             /////////////
             if (starsAreRight != null)
             {
-                s.AppendLine("Map Condition Difficulty: -20 Stars Are Right");
-                modifier += 20;
-                reportFavorables.AppendLine("-20 /-20: " +
+                s.AppendLine("Map Condition Difficulty: +20 Stars Are Right");
+                successModifier += 20;
+                reportFavorables.AppendLine("+20 / 20: " +
                                             "Cults_LRStarsAreRight".Translate(altar.SacrificeData.Entity.LabelCap));
             }
             else if (starsAreWrong != null)
             {
                 s.AppendLine("Map Condition Difficulty: +50 Stars Are Wrong");
-                successModifier += 50;
+                modifier += 50;
                 reportUnfavorables.AppendLine("+50 / 50: " +
                                               "Cults_LRStarsAreWrong".Translate(altar.SacrificeData.Entity.LabelCap));
             }


### PR DESCRIPTION
Previously when the stars were 'right' a +20 *difficulty* would be added. When the stars were 'wrong', a +50 success bonus was wrong.

These conflict with the description of these events in the English translation.

This patch makes 'right' stars give a +20 bonus to success, and wrong stars give a -50 malus.

Tested on my current game, and seems to be working great.