### PR TITLE
Linkable pews now provide 40% cover (was none)

### DIFF
--- a/Defs/ThingDefs_Buildings/Cults_BuildingsBuildable.xml
+++ b/Defs/ThingDefs_Buildings/Cults_BuildingsBuildable.xml
@@ -284,6 +284,7 @@
     </stuffCategories>
     <costStuffCount>25</costStuffCount>
     <pathCost>30</pathCost>
+    <fillPercent>0.40</fillPercent>
     <designationCategory>Furniture</designationCategory>
     <placingDraggableDimensions>1</placingDraggableDimensions>
     <rotatable>false</rotatable>


### PR DESCRIPTION
Pews didn't provide cover at all, which didn't seem right, so I've added it.

40% seems to be the standard for most buildings. It's slightly more than a dining chair (which provides 35%), but is the same as a shelf or bed.

Tested on my current game.