### PR TITLE
Guardians of Bast are now comfier in hotter climates.

### DIFF
--- a/Defs/ThingDefs_Races/Bast_Races.xml
+++ b/Defs/ThingDefs_Races/Bast_Races.xml
@@ -31,6 +31,7 @@
 		<statBases>
 			<MoveSpeed>7</MoveSpeed>
 			<ComfyTemperatureMin>-125</ComfyTemperatureMin>
+			<ComfyTemperatureMax>60</ComfyTemperatureMax>
 			<MarketValue>10000</MarketValue>
 		</statBases>
 		<tools>


### PR DESCRIPTION
Previously they had a default max temperature of 40°C. I've bumped this up to 60°C, which makes them better suited for the heat than a panther (50°C), but not completely immune to the hottest of temperatures.